### PR TITLE
Add installation guide for gem

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -3,6 +3,14 @@ jQuery UI themes for Rails
 
 All the pre rolled themes for jQuery UI packaged into a gem.
 
+Install
+-------
+In your Gemfile, add:
+
+    gem 'jquery-ui-themes'
+
+and run `bundle install`.
+
 Usage
 -----
 


### PR DESCRIPTION
Added a little new section on how to add this gem to your rails project. Helpful since project is named "jquery-ui-themes-rails" but the gem is named "jquery-ui-themes".
