### PR TITLE
Remove deprecation warning in Ruby 1.9

### DIFF
--- a/lib/jquery-ui-themes/google_cdn.rb
+++ b/lib/jquery-ui-themes/google_cdn.rb
@@ -1,6 +1,5 @@
 require 'httparty'
 require 'fileutils'
-require 'iconv'
 
 module JqueryUiThemes
 


### PR DESCRIPTION
iconv wasn't even required
