### PR TITLE
The imported assets goes into the vendor folder.

### DIFF
--- a/lib/tasks/jquery-ui-themes_tasks.rake
+++ b/lib/tasks/jquery-ui-themes_tasks.rake
@@ -8,16 +8,16 @@ namespace :jquery_ui_themes do
       
       require 'fileutils'
       
-      FileUtils.mkdir_p(File.expand_path('./app/assets/stylesheets/jquery-ui/'))
-      FileUtils.mkdir_p(File.expand_path('./app/assets/images/jquery-ui/' + args[:name]))
+      FileUtils.mkdir_p(File.expand_path("./vendor/assets/stylesheets/jquery-ui/#{args[:name]}"))
+      FileUtils.mkdir_p(File.expand_path("./vendor/assets/stylesheets/jquery-ui/#{args[:name]}/images"))
       
       css = File.read(File.expand_path(args[:path]))
       
-      File.open(File.expand_path("./app/assets/stylesheets/jquery-ui/#{args[:name]}.css.scss"), "w") do |file| 
-        file.puts css.gsub(/url\(['"]?images\/([^'"]+)['"]?\)/, 'url(image-path("jquery-ui/' + args[:name] + '/\1"))')
+      File.open(File.expand_path("./vendor/assets/stylesheets/jquery-ui/#{args[:name]}/theme.css.scss"), "w") do |file|
+        file.puts css.gsub(/url\(['"]?images\/([^'"]+)['"]?\)/, 'url(image-path("jquery-ui/' + args[:name] + '/images/\1"))')
       end
 
-      FileUtils.cp_r(File.dirname(File.expand_path(args[:path])) + '/images/.', File.expand_path('./app/assets/images/jquery-ui/' + args[:name]))
+      FileUtils.cp_r(File.dirname(File.expand_path(args[:path])) + '/images/.', File.expand_path("./vendor/assets/stylesheets/jquery-ui/#{args[:name]}/images/"))
     end
     
     desc 'Import themes from Google CDN'


### PR DESCRIPTION
The imported files are put into the vendor asset folder for stylesheets, as recommended for third party material.
This method has the advantage of keeping the theme images isolated in their own folder, even in the production environment, also avoiding possible name conflicts.

Everything is put inside a folder named ```jquery-ui/<name>```: both the theme main file and the theme images.

The images are put inside an ```images``` subfolder, while the theme main file name is kept ```theme.css.scss```, as it is in the jquery-ui distribution.

After importing, you need to

1. add the images folder to the assets precompile in the assets initializer
2. add to the ```application.css``` (or whatever you named it) file the include directive to the theme main file.