### PR TITLE
Quotes in image urls are supported.

### DIFF
--- a/lib/tasks/jquery-ui-themes_tasks.rake
+++ b/lib/tasks/jquery-ui-themes_tasks.rake
@@ -14,7 +14,7 @@ namespace :jquery_ui_themes do
       css = File.read(File.expand_path(args[:path]))
       
       File.open(File.expand_path("./app/assets/stylesheets/jquery-ui/#{args[:name]}.css.scss"), "w") do |file| 
-        file.puts css.gsub(/url\(images\/(.*)\)/, 'url(image-path(\'jquery-ui/' + args[:name] + '/\1\'))')
+        file.puts css.gsub(/url\(['"]?images\/([^'"]+)['"]?\)/, 'url(image-path("jquery-ui/' + args[:name] + '/\1"))')
       end
 
       FileUtils.cp_r(File.dirname(File.expand_path(args[:path])) + '/images/.', File.expand_path('./app/assets/images/jquery-ui/' + args[:name]))


### PR DESCRIPTION
Added the regexp to consider (optionally) the quotes in url directives (they are present in 1.11.4 distribution).